### PR TITLE
Unify vibe-coding headers and add sticky sidebar

### DIFF
--- a/learn/vibe-coding/en.html
+++ b/learn/vibe-coding/en.html
@@ -23,30 +23,41 @@
 </head>
 <body class="antialiased">
   
-<header id="header" class="bg-white/80 backdrop-blur-md sticky top-0 z-50 shadow-sm">
-    <nav class="container mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
-        <a href="#hero" class="text-xl font-bold text-gray-800">Vibe Coding</a>
-        <div class="hidden md:flex items-center space-x-6 text-sm">
-            <a href="#overview" class="nav-link">Overview</a>
-            <a href="#workflow" class="nav-link">Workflow</a>
-            <a href="#tools" class="nav-link">Key Tools</a>
-            <a href="#pros-cons" class="nav-link">Pros & Cons</a>
-            <a href="#future" class="nav-link">The Future</a>
-        </div>
-        <button id="mobile-menu-button" class="md:hidden p-2 rounded-md">
+<header class="bg-blue-800 text-white sticky top-0 z-50 shadow-md">
+    <nav class="max-w-4xl mx-auto flex items-center justify-between p-4">
+        <a href="../../index.html#home" class="text-2xl font-bold">Ram Woo</a>
+        <button id="nav-toggle" class="md:hidden focus:outline-none">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7" /></svg>
         </button>
+        <ul id="nav-menu" class="hidden md:flex space-x-6 text-sm font-semibold">
+            <li><a href="../../index.html#home" class="hover:text-blue-200">Home</a></li>
+            <li><a href="../../about.html" class="hover:text-blue-200">About</a></li>
+            <li><a href="../../experience.html" class="hover:text-blue-200">Experience</a></li>
+            <li><a href="../../learn/" class="hover:text-blue-200">Learn</a></li>
+            <li><a href="../../index.html#contact" class="hover:text-blue-200">Contact</a></li>
+        </ul>
     </nav>
-    <div id="mobile-menu" class="hidden md:hidden px-4 pb-4">
-        <a href="#overview" class="block py-2 text-sm nav-link">Overview</a>
-        <a href="#workflow" class="block py-2 text-sm nav-link">Workflow</a>
-        <a href="#tools" class="block py-2 text-sm nav-link">Key Tools</a>
-        <a href="#pros-cons" class="block py-2 text-sm nav-link">Pros & Cons</a>
-        <a href="#future" class="block py-2 text-sm nav-link">The Future</a>
-    </div>
+    <ul id="nav-menu-mobile" class="md:hidden hidden flex-col space-y-2 px-4 pb-4 text-sm font-semibold bg-blue-800">
+        <li><a href="../../index.html#home" class="block py-1 hover:text-blue-200">Home</a></li>
+        <li><a href="../../about.html" class="block py-1 hover:text-blue-200">About</a></li>
+        <li><a href="../../experience.html" class="block py-1 hover:text-blue-200">Experience</a></li>
+        <li><a href="../../learn/" class="block py-1 hover:text-blue-200">Learn</a></li>
+        <li><a href="../../index.html#contact" class="block py-1 hover:text-blue-200">Contact</a></li>
+    </ul>
 </header>
 
-    <main>
+<div class="flex">
+    <aside class="hidden md:block w-48 p-4 sticky top-20 self-start">
+        <ul class="space-y-2 text-sm font-semibold">
+            <li><a href="#overview" class="nav-link">Overview</a></li>
+            <li><a href="#workflow" class="nav-link">Workflow</a></li>
+            <li><a href="#tools" class="nav-link">Key Tools</a></li>
+            <li><a href="#pros-cons" class="nav-link">Pros &amp; Cons</a></li>
+            <li><a href="#future" class="nav-link">The Future</a></li>
+        </ul>
+    </aside>
+
+    <main class="flex-1">
         <section id="hero" class="min-h-[60vh] flex items-center bg-gray-50">
             <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
                 <h1 class="text-4xl md:text-6xl font-bold text-gray-800 leading-tight">Vibe Coding</h1>
@@ -186,6 +197,7 @@
             </div>
         </section>
     </main>
+</div>
 
     <footer class="bg-gray-800 text-white py-8">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center text-sm">
@@ -194,18 +206,11 @@
         </div>
     </footer>
 
- <script>
+    <script>
     document.addEventListener('DOMContentLoaded', () => {
-        const mobileMenuButton = document.getElementById('mobile-menu-button');
-        const mobileMenu = document.getElementById('mobile-menu');
-
-        mobileMenuButton.addEventListener('click', () => {
-            mobileMenu.classList.toggle('hidden');
-        });
-            
-            mobileMenuButton.addEventListener('click', () => {
-                mobileMenu.classList.toggle('hidden');
-            });
+        const toggle = document.getElementById('nav-toggle');
+        const mobileMenu = document.getElementById('nav-menu-mobile');
+        toggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
 
             // Navigation scroll highlighting
             const sections = document.querySelectorAll('section');

--- a/learn/vibe-coding/ko.html
+++ b/learn/vibe-coding/ko.html
@@ -26,33 +26,41 @@
     </style>
 </head>
 <body class="antialiased">
-  <header id="header" class="bg-white/80 backdrop-blur-md sticky top-0 z-50 shadow-sm">
-      <nav class="container mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
-          <a href="#hero" class="text-xl font-bold text-gray-800">바이브 코딩</a>
-          <div class="hidden md:flex items-center space-x-6 text-sm">
-              <a href="#overview" class="nav-link">개요</a>
-              <a href="#workflow" class="nav-link">작업 흐름</a>
-              <a href="#tools" class="nav-link">주요 도구</a>
-              <a href="#pros-cons" class="nav-link">장점과 과제</a>
-              <a href="#future" class="nav-link">미래</a>
-          </div>
-          <button id="mobile-menu-button" class="md:hidden p-2 rounded-md">
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7" />
-              </svg>
+  <header class="bg-blue-800 text-white sticky top-0 z-50 shadow-md">
+      <nav class="max-w-4xl mx-auto flex items-center justify-between p-4">
+          <a href="../../index.html#home" class="text-2xl font-bold">Ram Woo</a>
+          <button id="nav-toggle" class="md:hidden focus:outline-none">
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7" /></svg>
           </button>
+          <ul id="nav-menu" class="hidden md:flex space-x-6 text-sm font-semibold">
+              <li><a href="../../index.html#home" class="hover:text-blue-200">Home</a></li>
+              <li><a href="../../about.html" class="hover:text-blue-200">About</a></li>
+              <li><a href="../../experience.html" class="hover:text-blue-200">Experience</a></li>
+              <li><a href="../../learn/" class="hover:text-blue-200">Learn</a></li>
+              <li><a href="../../index.html#contact" class="hover:text-blue-200">Contact</a></li>
+          </ul>
       </nav>
-      <div id="mobile-menu" class="hidden md:hidden px-4 pb-4">
-          <a href="#overview" class="block py-2 text-sm nav-link">개요</a>
-          <a href="#workflow" class="block py-2 text-sm nav-link">작업 흐름</a>
-          <a href="#tools" class="block py-2 text-sm nav-link">주요 도구</a>
-          <a href="#pros-cons" class="block py-2 text-sm nav-link">장점과 과제</a>
-          <a href="#future" class="block py-2 text-sm nav-link">미래</a>
-      </div>
-  </header>
+      <ul id="nav-menu-mobile" class="md:hidden hidden flex-col space-y-2 px-4 pb-4 text-sm font-semibold bg-blue-800">
+          <li><a href="../../index.html#home" class="block py-1 hover:text-blue-200">Home</a></li>
+          <li><a href="../../about.html" class="block py-1 hover:text-blue-200">About</a></li>
+          <li><a href="../../experience.html" class="block py-1 hover:text-blue-200">Experience</a></li>
+          <li><a href="../../learn/" class="block py-1 hover:text-blue-200">Learn</a></li>
+          <li><a href="../../index.html#contact" class="block py-1 hover:text-blue-200">Contact</a></li>
+      </ul>
+</header>
 
+<div class="flex">
+    <aside class="hidden md:block w-48 p-4 sticky top-20 self-start">
+        <ul class="space-y-2 text-sm font-semibold">
+            <li><a href="#overview" class="nav-link">개요</a></li>
+            <li><a href="#workflow" class="nav-link">작업 흐름</a></li>
+            <li><a href="#tools" class="nav-link">주요 도구</a></li>
+            <li><a href="#pros-cons" class="nav-link">장점과 과제</a></li>
+            <li><a href="#future" class="nav-link">미래</a></li>
+        </ul>
+    </aside>
 
-    <main>
+    <main class="flex-1">
         <section id="hero" class="min-h-[60vh] flex items-center bg-gray-50">
             <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
                 <h1 class="text-4xl md:text-6xl font-bold text-gray-800 leading-tight">바이브 코딩</h1>
@@ -194,6 +202,7 @@
             </div>
         </section>
     </main>
+</div>
 
     <footer class="bg-gray-800 text-white py-8">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center text-sm">
@@ -204,13 +213,10 @@
 
   <script>
       document.addEventListener('DOMContentLoaded', () => {
-          const mobileMenuButton = document.getElementById('mobile-menu-button');
-          const mobileMenu = document.getElementById('mobile-menu');
+          const toggle = document.getElementById('nav-toggle');
+          const mobileMenu = document.getElementById('nav-menu-mobile');
+          toggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
 
-          mobileMenuButton.addEventListener('click', () => {
-              mobileMenu.classList.toggle('hidden');
-          });
-            
 
             // Navigation scroll highlighting
             const sections = document.querySelectorAll('section');


### PR DESCRIPTION
## Summary
- copy main site header to vibe coding pages
- remove old section links and mobile menu
- add sticky sidebar navigation and adjust layout
- simplify JS mobile menu logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849638dc85c8328856383ff4249b044