### PR TITLE
Unify Learn page header and add sidebar indexes

### DIFF
--- a/header.html
+++ b/header.html
@@ -1,0 +1,23 @@
+<!-- htmlhint doctype-first:false -->
+<header class="bg-blue-800 text-white sticky top-0 z-50 shadow-md">
+    <nav class="max-w-4xl mx-auto flex items-center justify-between p-4">
+        <a href="/index.html#home" class="text-2xl font-bold">Ram Woo</a>
+        <button id="nav-toggle" class="md:hidden focus:outline-none">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7" /></svg>
+        </button>
+        <ul id="nav-menu" class="hidden md:flex space-x-6 text-sm font-semibold">
+            <li><a href="/index.html#home" class="hover:text-blue-200">Home</a></li>
+            <li><a href="/about.html" class="hover:text-blue-200">About</a></li>
+            <li><a href="/experience.html" class="hover:text-blue-200">Experience</a></li>
+            <li><a href="/learn/" class="hover:text-blue-200">Learn</a></li>
+            <li><a href="/index.html#contact" class="hover:text-blue-200">Contact</a></li>
+        </ul>
+    </nav>
+    <ul id="nav-menu-mobile" class="md:hidden hidden flex-col space-y-2 px-4 pb-4 text-sm font-semibold bg-blue-800">
+        <li><a href="/index.html#home" class="block py-1 hover:text-blue-200">Home</a></li>
+        <li><a href="/about.html" class="block py-1 hover:text-blue-200">About</a></li>
+        <li><a href="/experience.html" class="block py-1 hover:text-blue-200">Experience</a></li>
+        <li><a href="/learn/" class="block py-1 hover:text-blue-200">Learn</a></li>
+        <li><a href="/index.html#contact" class="block py-1 hover:text-blue-200">Contact</a></li>
+    </ul>
+</header>

--- a/learn/index.html
+++ b/learn/index.html
@@ -14,35 +14,23 @@
     </style>
 </head>
 <body class="bg-gray-50 text-gray-800">
-    <header class="bg-blue-800 text-white sticky top-0 z-50 shadow-md">
-        <nav class="max-w-4xl mx-auto flex items-center justify-between p-4">
-            <a href="../index.html" class="text-2xl font-bold">Ram Woo</a>
-            <button id="nav-toggle" class="md:hidden focus:outline-none">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7" /></svg>
-            </button>
-            <ul id="nav-menu" class="hidden md:flex space-x-6 text-sm font-semibold">
-                <li><a href="../index.html#home" class="hover:text-blue-200">Home</a></li>
-                <li><a href="../index.html#about" class="hover:text-blue-200">About</a></li>
-                <li><a href="../index.html#experience" class="hover:text-blue-200">Experience</a></li>
-                <li><a href="./" class="hover:text-blue-200">Learn</a></li>
-                <li><a href="../index.html#contact" class="hover:text-blue-200">Contact</a></li>
-            </ul>
-        </nav>
-        <ul id="nav-menu-mobile" class="md:hidden hidden flex-col space-y-2 px-4 pb-4 text-sm font-semibold bg-blue-800">
-            <li><a href="../index.html#home" class="block py-1 hover:text-blue-200">Home</a></li>
-            <li><a href="../index.html#about" class="block py-1 hover:text-blue-200">About</a></li>
-            <li><a href="../index.html#experience" class="block py-1 hover:text-blue-200">Experience</a></li>
-            <li><a href="./" class="block py-1 hover:text-blue-200">Learn</a></li>
-            <li><a href="../index.html#contact" class="block py-1 hover:text-blue-200">Contact</a></li>
-        </ul>
-    </header>
+    <div id="site-header"></div>
     <main class="max-w-4xl mx-auto px-4">
         <section class="py-20 text-center">
             <h1 class="text-4xl md:text-5xl font-bold mb-4">Learn</h1>
             <p class="text-gray-600 max-w-2xl mx-auto">Explore interactive guides and resources. Choose a category to begin.</p>
         </section>
+    <div class="flex">
+        <aside class="hidden md:block w-48 p-4 sticky top-20 self-start">
+            <ul class="space-y-2 text-sm font-semibold">
+                <li><a href="#vibe-coding" class="nav-link">Vibe Coding</a></li>
+                <li><a href="#mcp-server" class="nav-link">MCP Server Setup</a></li>
+                <li><a href="#n8n-api" class="nav-link">n8n API Integration</a></li>
+            </ul>
+        </aside>
+        <div class="flex-1">
         <section class="pb-20 grid md:grid-cols-2 gap-8">
-            <div class="bg-white rounded-lg shadow-md p-6 flex flex-col justify-between hover:shadow-lg transition">
+            <div id="vibe-coding" class="bg-white rounded-lg shadow-md p-6 flex flex-col justify-between hover:shadow-lg transition">
                 <div>
                     <h2 class="text-2xl font-semibold mb-2">Vibe Coding</h2>
                     <p class="text-gray-600 text-sm mb-4">Interactive guide to vibe coding principles and workflow.</p>
@@ -53,7 +41,7 @@
                 </div>
             </div>
 
-            <div class="bg-white rounded-lg shadow-md p-6 flex flex-col justify-between hover:shadow-lg transition">
+            <div id="mcp-server" class="bg-white rounded-lg shadow-md p-6 flex flex-col justify-between hover:shadow-lg transition">
                 <div>
                     <h2 class="text-2xl font-semibold mb-2">MCP Server Setup</h2>
                     <p class="text-gray-600 text-sm mb-4">Popular tools and security tips for running your own MCP server.</p>
@@ -64,7 +52,7 @@
                 </div>
             </div>
 
-            <div class="bg-white rounded-lg shadow-md p-6 flex flex-col justify-between hover:shadow-lg transition">
+            <div id="n8n-api" class="bg-white rounded-lg shadow-md p-6 flex flex-col justify-between hover:shadow-lg transition">
                 <div>
                     <h2 class="text-2xl font-semibold mb-2">n8n API Integration</h2>
                     <p class="text-gray-600 text-sm mb-4">Hands-on guide for using LinkedIn and Notion APIs with n8n.</p>
@@ -76,15 +64,13 @@
             </div>
 
         </section>
+        </div>
+    </div>
     </main>
     <footer class="bg-blue-800 text-white text-center py-4">
         &copy; 2025 Ram Woo
     </footer>
-    <script>
-        const toggle = document.getElementById('nav-toggle');
-        const mobileMenu = document.getElementById('nav-menu-mobile');
-        toggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
-    </script>
+    <script src="/load-header.js"></script>
 </body>
 
 </html>

--- a/learn/mcp-server/en.html
+++ b/learn/mcp-server/en.html
@@ -40,30 +40,9 @@
         @keyframes fadeIn { from { opacity: 0; transform: translateY(20px); } to { opacity: 1; transform: translateY(0); } }
     </style>
 </head>
-<body class="bg-[#F8F7F4]">
+<body class="bg-indigo-50">
 
-    <header class="bg-blue-800 text-white sticky top-0 z-50 shadow-md">
-        <nav class="max-w-4xl mx-auto flex items-center justify-between p-4">
-            <a href="../../index.html#home" class="text-2xl font-bold">Ram Woo</a>
-            <button id="nav-toggle" class="md:hidden focus:outline-none">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7" /></svg>
-            </button>
-            <ul id="nav-menu" class="hidden md:flex space-x-6 text-sm font-semibold">
-                <li><a href="../../index.html#home" class="hover:text-blue-200">Home</a></li>
-                <li><a href="../../about.html" class="hover:text-blue-200">About</a></li>
-                <li><a href="../../experience.html" class="hover:text-blue-200">Experience</a></li>
-                <li><a href="../../learn/" class="hover:text-blue-200">Learn</a></li>
-                <li><a href="../../index.html#contact" class="hover:text-blue-200">Contact</a></li>
-            </ul>
-        </nav>
-        <ul id="nav-menu-mobile" class="md:hidden hidden flex-col space-y-2 px-4 pb-4 text-sm font-semibold bg-blue-800">
-            <li><a href="../../index.html#home" class="block py-1 hover:text-blue-200">Home</a></li>
-            <li><a href="../../about.html" class="block py-1 hover:text-blue-200">About</a></li>
-            <li><a href="../../experience.html" class="block py-1 hover:text-blue-200">Experience</a></li>
-            <li><a href="../../learn/" class="block py-1 hover:text-blue-200">Learn</a></li>
-            <li><a href="../../index.html#contact" class="block py-1 hover:text-blue-200">Contact</a></li>
-        </ul>
-    </header>
+    <div id="site-header"></div>
 
     <div class="flex">
     <aside class="hidden md:block w-48 p-4 sticky top-20 self-start">
@@ -351,9 +330,6 @@ mcp-server-slack</code></pre>
 
     <script>
         document.addEventListener('DOMContentLoaded', () => {
-            const toggle = document.getElementById('nav-toggle');
-            const mobileMenu = document.getElementById('nav-menu-mobile');
-            toggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
 
             const navLinks = document.querySelectorAll('.nav-link');
             const sections = document.querySelectorAll('.page-section');
@@ -487,6 +463,7 @@ mcp-server-slack</code></pre>
         });
     </script>
 
+    <script src="/load-header.js"></script>
 </body>
 
 </html>

--- a/learn/mcp-server/ko.html
+++ b/learn/mcp-server/ko.html
@@ -40,30 +40,9 @@
         @keyframes fadeIn { from { opacity: 0; transform: translateY(20px); } to { opacity: 1; transform: translateY(0); } }
     </style>
 </head>
-<body class="bg-[#F8F7F4]">
+<body class="bg-indigo-50">
 
-    <header class="bg-blue-800 text-white sticky top-0 z-50 shadow-md">
-        <nav class="max-w-4xl mx-auto flex items-center justify-between p-4">
-            <a href="../../index.html#home" class="text-2xl font-bold">Ram Woo</a>
-            <button id="nav-toggle" class="md:hidden focus:outline-none">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7" /></svg>
-            </button>
-            <ul id="nav-menu" class="hidden md:flex space-x-6 text-sm font-semibold">
-                <li><a href="../../index.html#home" class="hover:text-blue-200">Home</a></li>
-                <li><a href="../../about.html" class="hover:text-blue-200">About</a></li>
-                <li><a href="../../experience.html" class="hover:text-blue-200">Experience</a></li>
-                <li><a href="../../learn/" class="hover:text-blue-200">Learn</a></li>
-                <li><a href="../../index.html#contact" class="hover:text-blue-200">Contact</a></li>
-            </ul>
-        </nav>
-        <ul id="nav-menu-mobile" class="md:hidden hidden flex-col space-y-2 px-4 pb-4 text-sm font-semibold bg-blue-800">
-            <li><a href="../../index.html#home" class="block py-1 hover:text-blue-200">Home</a></li>
-            <li><a href="../../about.html" class="block py-1 hover:text-blue-200">About</a></li>
-            <li><a href="../../experience.html" class="block py-1 hover:text-blue-200">Experience</a></li>
-            <li><a href="../../learn/" class="block py-1 hover:text-blue-200">Learn</a></li>
-            <li><a href="../../index.html#contact" class="block py-1 hover:text-blue-200">Contact</a></li>
-        </ul>
-    </header>
+    <div id="site-header"></div>
 
     <div class="flex">
     <aside class="hidden md:block w-48 p-4 sticky top-20 self-start">
@@ -351,9 +330,6 @@ mcp-server-slack</code></pre>
 
     <script>
         document.addEventListener('DOMContentLoaded', () => {
-            const toggle = document.getElementById('nav-toggle');
-            const mobileMenu = document.getElementById('nav-menu-mobile');
-            toggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
 
             const navLinks = document.querySelectorAll('.nav-link');
             const sections = document.querySelectorAll('.page-section');
@@ -487,6 +463,7 @@ mcp-server-slack</code></pre>
         });
     </script>
 
+    <script src="/load-header.js"></script>
 </body>
 
 </html>

--- a/learn/n8n-api/en.html
+++ b/learn/n8n-api/en.html
@@ -19,30 +19,9 @@
         .chart-container { position: relative; width: 100%; max-width: 600px; margin-left: auto; margin-right: auto; height: 350px; max-height: 400px; }
     </style>
 </head>
-<body class="antialiased">
+<body class="antialiased bg-teal-50">
 
-<header class="bg-blue-800 text-white sticky top-0 z-50 shadow-md">
-    <nav class="max-w-4xl mx-auto flex items-center justify-between p-4">
-        <a href="../../index.html#home" class="text-2xl font-bold">Ram Woo</a>
-        <button id="nav-toggle" class="md:hidden focus:outline-none">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7" /></svg>
-        </button>
-        <ul id="nav-menu" class="hidden md:flex space-x-6 text-sm font-semibold">
-            <li><a href="../../index.html#home" class="hover:text-blue-200">Home</a></li>
-            <li><a href="../../about.html" class="hover:text-blue-200">About</a></li>
-            <li><a href="../../experience.html" class="hover:text-blue-200">Experience</a></li>
-            <li><a href="../../learn/" class="hover:text-blue-200">Learn</a></li>
-            <li><a href="../../index.html#contact" class="hover:text-blue-200">Contact</a></li>
-        </ul>
-    </nav>
-    <ul id="nav-menu-mobile" class="md:hidden hidden flex-col space-y-2 px-4 pb-4 text-sm font-semibold bg-blue-800">
-        <li><a href="../../index.html#home" class="block py-1 hover:text-blue-200">Home</a></li>
-        <li><a href="../../about.html" class="block py-1 hover:text-blue-200">About</a></li>
-        <li><a href="../../experience.html" class="block py-1 hover:text-blue-200">Experience</a></li>
-        <li><a href="../../learn/" class="block py-1 hover:text-blue-200">Learn</a></li>
-        <li><a href="../../index.html#contact" class="block py-1 hover:text-blue-200">Contact</a></li>
-    </ul>
-</header>
+<div id="site-header"></div>
 
 <div class="flex">
     <aside class="hidden md:block w-48 p-4 sticky top-20 self-start">
@@ -209,9 +188,6 @@
 
 <script>
 document.addEventListener('DOMContentLoaded', function () {
-    const toggle = document.getElementById('nav-toggle');
-    const mobileMenu = document.getElementById('nav-menu-mobile');
-    toggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
 
 
     const tabs = document.querySelectorAll('#tab-nav a');
@@ -559,5 +535,6 @@ document.addEventListener('DOMContentLoaded', function () {
     updateRequestPreview();
 });
 </script>
+    <script src="/load-header.js"></script>
 </body>
 </html>

--- a/learn/n8n-api/ko.html
+++ b/learn/n8n-api/ko.html
@@ -19,30 +19,9 @@
         .chart-container { position: relative; width: 100%; max-width: 600px; margin-left: auto; margin-right: auto; height: 350px; max-height: 400px; }
     </style>
 </head>
-<body class="antialiased">
+<body class="antialiased bg-teal-50">
 
-<header class="bg-blue-800 text-white sticky top-0 z-50 shadow-md">
-    <nav class="max-w-4xl mx-auto flex items-center justify-between p-4">
-        <a href="../../index.html#home" class="text-2xl font-bold">Ram Woo</a>
-        <button id="nav-toggle" class="md:hidden focus:outline-none">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7" /></svg>
-        </button>
-        <ul id="nav-menu" class="hidden md:flex space-x-6 text-sm font-semibold">
-            <li><a href="../../index.html#home" class="hover:text-blue-200">Home</a></li>
-            <li><a href="../../about.html" class="hover:text-blue-200">About</a></li>
-            <li><a href="../../experience.html" class="hover:text-blue-200">Experience</a></li>
-            <li><a href="../../learn/" class="hover:text-blue-200">Learn</a></li>
-            <li><a href="../../index.html#contact" class="hover:text-blue-200">Contact</a></li>
-        </ul>
-    </nav>
-    <ul id="nav-menu-mobile" class="md:hidden hidden flex-col space-y-2 px-4 pb-4 text-sm font-semibold bg-blue-800">
-        <li><a href="../../index.html#home" class="block py-1 hover:text-blue-200">Home</a></li>
-        <li><a href="../../about.html" class="block py-1 hover:text-blue-200">About</a></li>
-        <li><a href="../../experience.html" class="block py-1 hover:text-blue-200">Experience</a></li>
-        <li><a href="../../learn/" class="block py-1 hover:text-blue-200">Learn</a></li>
-        <li><a href="../../index.html#contact" class="block py-1 hover:text-blue-200">Contact</a></li>
-    </ul>
-</header>
+<div id="site-header"></div>
 
 <div class="flex">
     <aside class="hidden md:block w-48 p-4 sticky top-20 self-start">
@@ -206,9 +185,6 @@
 
 <script>
 document.addEventListener('DOMContentLoaded', function () {
-    const toggle = document.getElementById('nav-toggle');
-    const mobileMenu = document.getElementById('nav-menu-mobile');
-    toggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
 
 
     const tabs = document.querySelectorAll('#tab-nav a');
@@ -551,5 +527,6 @@ document.addEventListener('DOMContentLoaded', function () {
     updateRequestPreview();
 });
 </script>
+    <script src="/load-header.js"></script>
 </body>
 </html>

--- a/learn/vibe-coding/en.html
+++ b/learn/vibe-coding/en.html
@@ -21,30 +21,9 @@
         .tool-toggle.active { background-color: #1d4ed8; color: white; }
     </style>
 </head>
-<body class="antialiased">
+<body class="antialiased bg-orange-50">
   
-<header class="bg-blue-800 text-white sticky top-0 z-50 shadow-md">
-    <nav class="max-w-4xl mx-auto flex items-center justify-between p-4">
-        <a href="../../index.html#home" class="text-2xl font-bold">Ram Woo</a>
-        <button id="nav-toggle" class="md:hidden focus:outline-none">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7" /></svg>
-        </button>
-        <ul id="nav-menu" class="hidden md:flex space-x-6 text-sm font-semibold">
-            <li><a href="../../index.html#home" class="hover:text-blue-200">Home</a></li>
-            <li><a href="../../about.html" class="hover:text-blue-200">About</a></li>
-            <li><a href="../../experience.html" class="hover:text-blue-200">Experience</a></li>
-            <li><a href="../../learn/" class="hover:text-blue-200">Learn</a></li>
-            <li><a href="../../index.html#contact" class="hover:text-blue-200">Contact</a></li>
-        </ul>
-    </nav>
-    <ul id="nav-menu-mobile" class="md:hidden hidden flex-col space-y-2 px-4 pb-4 text-sm font-semibold bg-blue-800">
-        <li><a href="../../index.html#home" class="block py-1 hover:text-blue-200">Home</a></li>
-        <li><a href="../../about.html" class="block py-1 hover:text-blue-200">About</a></li>
-        <li><a href="../../experience.html" class="block py-1 hover:text-blue-200">Experience</a></li>
-        <li><a href="../../learn/" class="block py-1 hover:text-blue-200">Learn</a></li>
-        <li><a href="../../index.html#contact" class="block py-1 hover:text-blue-200">Contact</a></li>
-    </ul>
-</header>
+<div id="site-header"></div>
 
 <div class="flex">
     <aside class="hidden md:block w-48 p-4 sticky top-20 self-start">
@@ -208,10 +187,6 @@
 
     <script>
     document.addEventListener('DOMContentLoaded', () => {
-        const toggle = document.getElementById('nav-toggle');
-        const mobileMenu = document.getElementById('nav-menu-mobile');
-        toggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
-
             // Navigation scroll highlighting
             const sections = document.querySelectorAll('section');
             const navLinks = document.querySelectorAll('.nav-link');
@@ -394,5 +369,6 @@
             });
         });
     </script>
+    <script src="/load-header.js"></script>
 </body>
 </html>

--- a/learn/vibe-coding/ko.html
+++ b/learn/vibe-coding/ko.html
@@ -25,29 +25,8 @@
         .tool-toggle.active { background-color: #1d4ed8; color: white; }
     </style>
 </head>
-<body class="antialiased">
-  <header class="bg-blue-800 text-white sticky top-0 z-50 shadow-md">
-      <nav class="max-w-4xl mx-auto flex items-center justify-between p-4">
-          <a href="../../index.html#home" class="text-2xl font-bold">Ram Woo</a>
-          <button id="nav-toggle" class="md:hidden focus:outline-none">
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7" /></svg>
-          </button>
-          <ul id="nav-menu" class="hidden md:flex space-x-6 text-sm font-semibold">
-              <li><a href="../../index.html#home" class="hover:text-blue-200">Home</a></li>
-              <li><a href="../../about.html" class="hover:text-blue-200">About</a></li>
-              <li><a href="../../experience.html" class="hover:text-blue-200">Experience</a></li>
-              <li><a href="../../learn/" class="hover:text-blue-200">Learn</a></li>
-              <li><a href="../../index.html#contact" class="hover:text-blue-200">Contact</a></li>
-          </ul>
-      </nav>
-      <ul id="nav-menu-mobile" class="md:hidden hidden flex-col space-y-2 px-4 pb-4 text-sm font-semibold bg-blue-800">
-          <li><a href="../../index.html#home" class="block py-1 hover:text-blue-200">Home</a></li>
-          <li><a href="../../about.html" class="block py-1 hover:text-blue-200">About</a></li>
-          <li><a href="../../experience.html" class="block py-1 hover:text-blue-200">Experience</a></li>
-          <li><a href="../../learn/" class="block py-1 hover:text-blue-200">Learn</a></li>
-          <li><a href="../../index.html#contact" class="block py-1 hover:text-blue-200">Contact</a></li>
-      </ul>
-</header>
+<body class="antialiased bg-orange-50">
+  <div id="site-header"></div>
 
 <div class="flex">
     <aside class="hidden md:block w-48 p-4 sticky top-20 self-start">
@@ -213,10 +192,6 @@
 
   <script>
       document.addEventListener('DOMContentLoaded', () => {
-          const toggle = document.getElementById('nav-toggle');
-          const mobileMenu = document.getElementById('nav-menu-mobile');
-          toggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
-
 
             // Navigation scroll highlighting
             const sections = document.querySelectorAll('section');
@@ -400,5 +375,6 @@
             });
         });
     </script>
+    <script src="/load-header.js"></script>
 </body>
 </html>

--- a/load-header.js
+++ b/load-header.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const placeholder = document.getElementById('site-header');
+  if (!placeholder) return;
+  fetch('/header.html')
+    .then(r => r.text())
+    .then(html => {
+      placeholder.innerHTML = html;
+      const toggle = document.getElementById('nav-toggle');
+      const mobileMenu = document.getElementById('nav-menu-mobile');
+      if (toggle && mobileMenu) {
+        toggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
+      }
+    })
+    .catch(err => console.error('Failed to load header:', err));
+});


### PR DESCRIPTION
## Summary
- add reusable header.html and loader script
- use the shared header on all pages under `learn`
- give learn pages their own subtle background colors
- index the learn overview with a new sidebar menu

## Testing
- `htmlhint *.html learn/**/*.html`

------
https://chatgpt.com/codex/tasks/task_e_6851719a18fc8328b824426f4fee5ae8