### PR TITLE
Add dropdown navigation and n8n API page

### DIFF
--- a/about.html
+++ b/about.html
@@ -22,11 +22,19 @@
             <button id="nav-toggle" class="md:hidden focus:outline-none">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7" /></svg>
             </button>
-            <ul id="nav-menu" class="hidden md:flex space-x-6 text-sm font-semibold">
+            <ul id="nav-menu" class="hidden md:flex space-x-6 text-sm font-semibold items-center">
                 <li><a href="index.html#home" class="hover:text-blue-200">Home</a></li>
                 <li><a href="about.html" class="hover:text-blue-200">About</a></li>
                 <li><a href="experience.html" class="hover:text-blue-200">Experience</a></li>
-                <li><a href="learn/" class="hover:text-blue-200">Learn</a></li>
+                <li class="relative group">
+                    <span class="hover:text-blue-200 cursor-pointer">Learn</span>
+                    <ul class="absolute left-0 mt-2 bg-blue-800 text-white rounded shadow-md space-y-1 invisible opacity-0 group-hover:visible group-hover:opacity-100 transition">
+                        <li><a href="learn/" class="block px-4 py-2 hover:bg-blue-700 whitespace-nowrap">Overview</a></li>
+                        <li><a href="learn/vibe-coding/ko.html" class="block px-4 py-2 hover:bg-blue-700 whitespace-nowrap">Vibe Coding (KO)</a></li>
+                        <li><a href="learn/vibe-coding/en.html" class="block px-4 py-2 hover:bg-blue-700 whitespace-nowrap">Vibe Coding (EN)</a></li>
+                        <li><a href="learn/n8n-api.html" class="block px-4 py-2 hover:bg-blue-700 whitespace-nowrap">n8n API</a></li>
+                    </ul>
+                </li>
                 <li><a href="index.html#contact" class="hover:text-blue-200">Contact</a></li>
             </ul>
         </nav>
@@ -34,7 +42,19 @@
             <li><a href="index.html#home" class="block py-1 hover:text-blue-200">Home</a></li>
             <li><a href="about.html" class="block py-1 hover:text-blue-200">About</a></li>
             <li><a href="experience.html" class="block py-1 hover:text-blue-200">Experience</a></li>
-            <li><a href="learn/" class="block py-1 hover:text-blue-200">Learn</a></li>
+            <li>
+                <button id="learn-mobile-toggle" class="w-full text-left flex justify-between items-center py-1 hover:text-blue-200">Learn
+                    <svg id="learn-mobile-icon" xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 transform transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                    </svg>
+                </button>
+                <ul id="learn-mobile-menu" class="hidden pl-4 space-y-1">
+                    <li><a href="learn/" class="block py-1 hover:text-blue-200">Overview</a></li>
+                    <li><a href="learn/vibe-coding/ko.html" class="block py-1 hover:text-blue-200">Vibe Coding (KO)</a></li>
+                    <li><a href="learn/vibe-coding/en.html" class="block py-1 hover:text-blue-200">Vibe Coding (EN)</a></li>
+                    <li><a href="learn/n8n-api.html" class="block py-1 hover:text-blue-200">n8n API</a></li>
+                </ul>
+            </li>
             <li><a href="index.html#contact" class="block py-1 hover:text-blue-200">Contact</a></li>
         </ul>
     </header>
@@ -61,7 +81,17 @@
     <script>
         const toggle = document.getElementById('nav-toggle');
         const mobileMenu = document.getElementById('nav-menu-mobile');
-        toggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
+        if (toggle) toggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
+
+        const learnToggle = document.getElementById('learn-mobile-toggle');
+        const learnMenu = document.getElementById('learn-mobile-menu');
+        const learnIcon = document.getElementById('learn-mobile-icon');
+        if (learnToggle) {
+            learnToggle.addEventListener('click', () => {
+                learnMenu.classList.toggle('hidden');
+                learnIcon.classList.toggle('rotate-180');
+            });
+        }
 
         const observer = new IntersectionObserver(entries => {
             entries.forEach(entry => {

--- a/experience.html
+++ b/experience.html
@@ -22,11 +22,19 @@
             <button id="nav-toggle" class="md:hidden focus:outline-none">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7" /></svg>
             </button>
-            <ul id="nav-menu" class="hidden md:flex space-x-6 text-sm font-semibold">
+            <ul id="nav-menu" class="hidden md:flex space-x-6 text-sm font-semibold items-center">
                 <li><a href="index.html#home" class="hover:text-blue-200">Home</a></li>
                 <li><a href="about.html" class="hover:text-blue-200">About</a></li>
                 <li><a href="experience.html" class="hover:text-blue-200">Experience</a></li>
-                <li><a href="learn/" class="hover:text-blue-200">Learn</a></li>
+                <li class="relative group">
+                    <span class="hover:text-blue-200 cursor-pointer">Learn</span>
+                    <ul class="absolute left-0 mt-2 bg-blue-800 text-white rounded shadow-md space-y-1 invisible opacity-0 group-hover:visible group-hover:opacity-100 transition">
+                        <li><a href="learn/" class="block px-4 py-2 hover:bg-blue-700 whitespace-nowrap">Overview</a></li>
+                        <li><a href="learn/vibe-coding/ko.html" class="block px-4 py-2 hover:bg-blue-700 whitespace-nowrap">Vibe Coding (KO)</a></li>
+                        <li><a href="learn/vibe-coding/en.html" class="block px-4 py-2 hover:bg-blue-700 whitespace-nowrap">Vibe Coding (EN)</a></li>
+                        <li><a href="learn/n8n-api.html" class="block px-4 py-2 hover:bg-blue-700 whitespace-nowrap">n8n API</a></li>
+                    </ul>
+                </li>
                 <li><a href="index.html#contact" class="hover:text-blue-200">Contact</a></li>
             </ul>
         </nav>
@@ -34,7 +42,19 @@
             <li><a href="index.html#home" class="block py-1 hover:text-blue-200">Home</a></li>
             <li><a href="about.html" class="block py-1 hover:text-blue-200">About</a></li>
             <li><a href="experience.html" class="block py-1 hover:text-blue-200">Experience</a></li>
-            <li><a href="learn/" class="block py-1 hover:text-blue-200">Learn</a></li>
+            <li>
+                <button id="learn-mobile-toggle" class="w-full text-left flex justify-between items-center py-1 hover:text-blue-200">Learn
+                    <svg id="learn-mobile-icon" xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 transform transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                    </svg>
+                </button>
+                <ul id="learn-mobile-menu" class="hidden pl-4 space-y-1">
+                    <li><a href="learn/" class="block py-1 hover:text-blue-200">Overview</a></li>
+                    <li><a href="learn/vibe-coding/ko.html" class="block py-1 hover:text-blue-200">Vibe Coding (KO)</a></li>
+                    <li><a href="learn/vibe-coding/en.html" class="block py-1 hover:text-blue-200">Vibe Coding (EN)</a></li>
+                    <li><a href="learn/n8n-api.html" class="block py-1 hover:text-blue-200">n8n API</a></li>
+                </ul>
+            </li>
             <li><a href="index.html#contact" class="block py-1 hover:text-blue-200">Contact</a></li>
         </ul>
     </header>
@@ -53,7 +73,17 @@
     <script>
         const toggle = document.getElementById('nav-toggle');
         const mobileMenu = document.getElementById('nav-menu-mobile');
-        toggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
+        if (toggle) toggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
+
+        const learnToggle = document.getElementById('learn-mobile-toggle');
+        const learnMenu = document.getElementById('learn-mobile-menu');
+        const learnIcon = document.getElementById('learn-mobile-icon');
+        if (learnToggle) {
+            learnToggle.addEventListener('click', () => {
+                learnMenu.classList.toggle('hidden');
+                learnIcon.classList.toggle('rotate-180');
+            });
+        }
 
         const observer = new IntersectionObserver(entries => {
             entries.forEach(entry => {

--- a/index.html
+++ b/index.html
@@ -22,11 +22,19 @@
             <button id="nav-toggle" class="md:hidden focus:outline-none">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7" /></svg>
             </button>
-            <ul id="nav-menu" class="hidden md:flex space-x-6 text-sm font-semibold">
+            <ul id="nav-menu" class="hidden md:flex space-x-6 text-sm font-semibold items-center">
                 <li><a href="index.html#home" class="hover:text-blue-200">Home</a></li>
                 <li><a href="about.html" class="hover:text-blue-200">About</a></li>
                 <li><a href="experience.html" class="hover:text-blue-200">Experience</a></li>
-                <li><a href="learn/" class="hover:text-blue-200">Learn</a></li>
+                <li class="relative group">
+                    <span class="hover:text-blue-200 cursor-pointer">Learn</span>
+                    <ul class="absolute left-0 mt-2 bg-blue-800 text-white rounded shadow-md space-y-1 invisible opacity-0 group-hover:visible group-hover:opacity-100 transition">
+                        <li><a href="learn/" class="block px-4 py-2 hover:bg-blue-700 whitespace-nowrap">Overview</a></li>
+                        <li><a href="learn/vibe-coding/ko.html" class="block px-4 py-2 hover:bg-blue-700 whitespace-nowrap">Vibe Coding (KO)</a></li>
+                        <li><a href="learn/vibe-coding/en.html" class="block px-4 py-2 hover:bg-blue-700 whitespace-nowrap">Vibe Coding (EN)</a></li>
+                        <li><a href="learn/n8n-api.html" class="block px-4 py-2 hover:bg-blue-700 whitespace-nowrap">n8n API</a></li>
+                    </ul>
+                </li>
                 <li><a href="index.html#contact" class="hover:text-blue-200">Contact</a></li>
             </ul>
         </nav>
@@ -34,7 +42,19 @@
             <li><a href="index.html#home" class="block py-1 hover:text-blue-200">Home</a></li>
             <li><a href="about.html" class="block py-1 hover:text-blue-200">About</a></li>
             <li><a href="experience.html" class="block py-1 hover:text-blue-200">Experience</a></li>
-            <li><a href="learn/" class="block py-1 hover:text-blue-200">Learn</a></li>
+            <li>
+                <button id="learn-mobile-toggle" class="w-full text-left flex justify-between items-center py-1 hover:text-blue-200">Learn
+                    <svg id="learn-mobile-icon" xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 transform transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                    </svg>
+                </button>
+                <ul id="learn-mobile-menu" class="hidden pl-4 space-y-1">
+                    <li><a href="learn/" class="block py-1 hover:text-blue-200">Overview</a></li>
+                    <li><a href="learn/vibe-coding/ko.html" class="block py-1 hover:text-blue-200">Vibe Coding (KO)</a></li>
+                    <li><a href="learn/vibe-coding/en.html" class="block py-1 hover:text-blue-200">Vibe Coding (EN)</a></li>
+                    <li><a href="learn/n8n-api.html" class="block py-1 hover:text-blue-200">n8n API</a></li>
+                </ul>
+            </li>
             <li><a href="index.html#contact" class="block py-1 hover:text-blue-200">Contact</a></li>
         </ul>
     </header>
@@ -43,7 +63,7 @@
             <h1 class="text-4xl md:text-6xl font-bold">Ram Woo</h1>
             <p class="text-lg md:text-xl">Accounting Specialist</p>
             <p class="max-w-2xl">Hello! I'm Ram Woo, an accounting professional specializing in corporate finance and taxation. I strive to provide accurate and timely financial insights for businesses.</p>
-            <a href="about.html" class="mt-4 inline-block bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700 transition">Learn More</a>
+            <a href="/about.html" class="mt-4 inline-block bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700 transition">Learn More</a>
         </section>
 
         <section id="contact" class="py-20 fade-up">
@@ -60,7 +80,17 @@
     <script>
         const toggle = document.getElementById('nav-toggle');
         const mobileMenu = document.getElementById('nav-menu-mobile');
-        toggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
+        if (toggle) toggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
+
+        const learnToggle = document.getElementById('learn-mobile-toggle');
+        const learnMenu = document.getElementById('learn-mobile-menu');
+        const learnIcon = document.getElementById('learn-mobile-icon');
+        if (learnToggle) {
+            learnToggle.addEventListener('click', () => {
+                learnMenu.classList.toggle('hidden');
+                learnIcon.classList.toggle('rotate-180');
+            });
+        }
 
         const observer = new IntersectionObserver(entries => {
             entries.forEach(entry => {

--- a/learn/n8n-api.html
+++ b/learn/n8n-api.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Interactive guides on vibe coding and other topics">
-    <title>Learn</title>
+    <meta name="description" content="n8n API quick reference">
+    <title>n8n API</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -16,7 +16,7 @@
 <body class="bg-gray-50 text-gray-800">
     <header class="bg-blue-800 text-white sticky top-0 z-50 shadow-md">
         <nav class="max-w-4xl mx-auto flex items-center justify-between p-4">
-            <a href="../index.html" class="text-2xl font-bold">Ram Woo</a>
+            <a href="../index.html#home" class="text-2xl font-bold">Ram Woo</a>
             <button id="nav-toggle" class="md:hidden focus:outline-none">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7" /></svg>
             </button>
@@ -56,33 +56,30 @@
             <li><a href="../index.html#contact" class="block py-1 hover:text-blue-200">Contact</a></li>
         </ul>
     </header>
-    <main class="max-w-4xl mx-auto px-4">
-        <section class="py-20 text-center">
-            <h1 class="text-4xl md:text-5xl font-bold mb-4">Learn</h1>
-            <p class="text-gray-600 max-w-2xl mx-auto">Explore interactive guides and resources. Choose a category to begin.</p>
-        </section>
-        <section class="pb-20 grid md:grid-cols-2 gap-8">
-            <div class="bg-white rounded-lg shadow-md p-6 flex flex-col justify-between hover:shadow-lg transition">
-                <div>
-                    <h2 class="text-2xl font-semibold mb-2">Vibe Coding</h2>
-                    <p class="text-gray-600 text-sm mb-4">Interactive guide to vibe coding principles and workflow.</p>
-                </div>
-                <div class="flex justify-center space-x-4">
-                    <a href="vibe-coding/ko.html" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition">한국어</a>
-                    <a href="vibe-coding/en.html" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition">English</a>
-                </div>
-            </div>
-            <div class="bg-white rounded-lg shadow-md p-6 flex flex-col justify-between hover:shadow-lg transition">
-                <div>
-                    <h2 class="text-2xl font-semibold mb-2">n8n API</h2>
-                    <p class="text-gray-600 text-sm mb-4">Reference guide for interacting with n8n programmatically.</p>
-                </div>
-                <div class="flex justify-center">
-                    <a href="n8n-api.html" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition">Open</a>
-                </div>
-            </div>
-        </section>
-    </main>
+    <div class="max-w-4xl mx-auto px-4 py-6 flex">
+        <aside class="w-48 mr-6">
+            <h2 class="font-semibold mb-2">Endpoints</h2>
+            <ul class="space-y-1 text-sm" id="api-menu">
+                <li><a href="#intro" class="block py-1 hover:text-blue-600">Introduction</a></li>
+                <li><a href="#auth" class="block py-1 hover:text-blue-600">Authentication</a></li>
+                <li><a href="#workflows" class="block py-1 hover:text-blue-600">Workflows</a></li>
+            </ul>
+        </aside>
+        <main class="flex-1 space-y-8">
+            <section id="intro">
+                <h1 class="text-3xl font-bold mb-2">n8n API</h1>
+                <p class="text-gray-700">Basic information about n8n API usage.</p>
+            </section>
+            <section id="auth">
+                <h2 class="text-2xl font-bold mb-2">Authentication</h2>
+                <p class="text-gray-700">How to authenticate with the API.</p>
+            </section>
+            <section id="workflows">
+                <h2 class="text-2xl font-bold mb-2">Workflows</h2>
+                <p class="text-gray-700">Managing workflows via API.</p>
+            </section>
+        </main>
+    </div>
     <footer class="bg-blue-800 text-white text-center py-4">
         &copy; 2025 Ram Woo
     </footer>
@@ -102,5 +99,4 @@
         }
     </script>
 </body>
-
 </html>


### PR DESCRIPTION
## Summary
- fix Learn More link
- add Learn dropdown navigation for desktop and mobile
- include JS for dropdown toggling
- add n8n API documentation page and link
- show n8n API card in Learn index

## Testing
- `ls learn`


------
https://chatgpt.com/codex/tasks/task_e_6854a671012083289e3e71e89689a270