### PR TITLE
Fix navigation hover and cleanup n8n guide

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="How to reach Ram Woo">
+    <title>Contact Ram Woo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <style>
+        body { font-family: 'Inter', sans-serif; }
+        .fade-up { opacity: 0; transform: translateY(20px); transition: opacity 0.6s ease-out, transform 0.6s ease-out; }
+        .fade-up.show { opacity: 1; transform: translateY(0); }
+    </style>
+</head>
+<body class="bg-gray-50 text-gray-800">
+    <div id="site-header"></div>
+    <main class="max-w-4xl mx-auto px-4 py-8">
+        <section id="contact" class="fade-up">
+            <h1 class="text-3xl font-bold mb-4 text-center">Contact</h1>
+            <p>Email: <a href="mailto:ram@kakao.com" class="text-blue-600 hover:underline">ram@kakao.com</a></p>
+            <p>LinkedIn: <a href="https://www.linkedin.com/in/ram-woo-413759284/" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">Ram Woo</a></p>
+        </section>
+    </main>
+    <footer class="bg-blue-800 text-white text-center py-4">
+        &copy; 2025 Ram Woo
+    </footer>
+    <script>
+        const observer = new IntersectionObserver(entries => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('show');
+                }
+            });
+        }, { threshold: 0.1 });
+
+        document.querySelectorAll('.fade-up').forEach(el => observer.observe(el));
+    </script>
+    <script src="/load-header.js"></script>
+</body>
+</html>

--- a/header.html
+++ b/header.html
@@ -9,15 +9,15 @@
             <li><a href="/index.html#home" class="hover:text-blue-200">Home</a></li>
             <li><a href="/about.html" class="hover:text-blue-200">About</a></li>
             <li><a href="/experience.html" class="hover:text-blue-200">Experience</a></li>
-            <li id="learn-item" class="relative">
-                <a href="/learn/" id="learn-link" class="hover:text-blue-200">Learn</a>
-                <ul id="learn-dropdown" class="absolute hidden left-0 mt-2 bg-blue-800 text-white rounded shadow-lg whitespace-nowrap p-2 space-y-1">
+            <li id="learn-item" class="relative group">
+                <a href="/learn/index.html" id="learn-link" class="hover:text-blue-200">Learn</a>
+                <ul id="learn-dropdown" class="absolute hidden group-hover:block left-0 mt-2 bg-blue-800 text-white rounded shadow-lg whitespace-nowrap p-2 space-y-1">
                     <li><a href="/learn/vibe-coding/en.html" class="block px-4 py-1 hover:text-blue-200">Vibe Coding</a></li>
                     <li><a href="/learn/mcp-server/en.html" class="block px-4 py-1 hover:text-blue-200">MCP Server</a></li>
                     <li><a href="/learn/n8n-api/en.html" class="block px-4 py-1 hover:text-blue-200">n8n API</a></li>
                 </ul>
             </li>
-            <li><a href="/index.html#contact" class="hover:text-blue-200">Contact</a></li>
+            <li><a href="/contact.html" class="hover:text-blue-200">Contact</a></li>
         </ul>
     </nav>
     <ul id="nav-menu-mobile" class="md:hidden hidden flex-col space-y-2 px-4 pb-4 text-sm font-semibold bg-blue-800">
@@ -32,6 +32,6 @@
                 <li><a href="/learn/n8n-api/en.html" class="block py-1 hover:text-blue-200">n8n API</a></li>
             </ul>
         </li>
-        <li><a href="/index.html#contact" class="block py-1 hover:text-blue-200">Contact</a></li>
+        <li><a href="/contact.html" class="block py-1 hover:text-blue-200">Contact</a></li>
     </ul>
 </header>

--- a/learn/n8n-api/en.html
+++ b/learn/n8n-api/en.html
@@ -11,10 +11,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700&display=swap" rel="stylesheet">
     <style>
         body { font-family: 'Inter', sans-serif; background-color: #F9F9F9; color: #1f2937; }
-        .tab-active { border-bottom-color: #2563eb; color: #2563eb; font-weight: 500; }
-        .tab-inactive { border-bottom-color: transparent; color: #6b7280; }
-        .content-section { display: none; }
-        .content-section.active { display: block; }
+        /* sections are all visible by default */
         .code-block { background-color: #1f2937; color: #d1d5db; padding: 1rem; border-radius: 0.5rem; font-family: monospace; white-space: pre-wrap; word-break: break-all; }
         .chart-container { position: relative; width: 100%; max-width: 600px; margin-left: auto; margin-right: auto; height: 350px; max-height: 400px; }
     </style>
@@ -35,15 +32,7 @@
     </aside>
       <main class="flex-1">
         <section id="home" class="container mx-auto p-4 md:p-8">
-            <nav id="tab-nav" class="mb-8 border-b border-slate-200">
-                  <ul class="flex flex-wrap -mb-px text-sm font-medium text-center">
-                    <li class="mr-2"><a href="#" class="inline-block p-4 border-b-2 rounded-t-lg tab-active" data-tab="home">Overview</a></li>
-                    <li class="mr-2"><a href="#" class="inline-block p-4 border-b-2 rounded-t-lg tab-inactive" data-tab="http-basics">HTTP Request Basics</a></li>
-                    <li class="mr-2"><a href="#" class="inline-block p-4 border-b-2 rounded-t-lg tab-inactive" data-tab="linkedin">LinkedIn Integration</a></li>
-                    <li class="mr-2"><a href="#" class="inline-block p-4 border-b-2 rounded-t-lg tab-inactive" data-tab="notion">Notion Integration</a></li>
-                    <li><a href="#" class="inline-block p-4 border-b-2 rounded-t-lg tab-inactive" data-tab="advanced">Advanced Workflows</a></li>
-                </ul>
-            </nav>
+            <!-- removed page-level tab navigation -->
             <div class="bg-white p-6 rounded-lg shadow-sm">
                 <h2 class="text-2xl font-bold mb-4">Unlock the Full Potential of n8n</h2>
                 <p class="mb-4 text-slate-600">This guide demonstrates how to directly call APIs of services like LinkedIn and Notion using n8n's powerful <code>HTTP Request</code> node. Learn to implement functionalities not available through built-in nodes and build sophisticated custom automation workflows tailored to your business needs. Each section combines theoretical knowledge with practical examples, helping you become an API integration expert.</p>
@@ -192,10 +181,7 @@
 </div>
 <script>
 document.addEventListener('DOMContentLoaded', function () {
-  const tabs = document.querySelectorAll('#tab-nav a');
-    const sidebarLinks = document.querySelectorAll('aside .nav-link');
 
-    const sections = document.querySelectorAll('.content-section');
 
     const httpMethodSelect = document.getElementById('http-method');
     const addHeaderBtn = document.getElementById('add-header');
@@ -209,25 +195,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const accordionButtons = document.querySelectorAll('[data-accordion-target]');
 
 
-    function showSection(targetId) {
-        tabs.forEach(t => {
-            if (t.dataset.tab === targetId) {
-                t.classList.add('tab-active');
-                t.classList.remove('tab-inactive');
-            } else {
-                t.classList.remove('tab-active');
-                t.classList.add('tab-inactive');
-            }
-        });
-        sections.forEach(section => {
-            if (section.id === targetId) {
-                section.classList.add('active');
-            } else {
-                section.classList.remove('active');
-            }
-        });
-        document.getElementById(targetId)?.scrollIntoView({ behavior: 'smooth' });
-    }
+    // sections are navigated via normal anchors
 
 
     const linkedinData = {
@@ -357,22 +325,7 @@ document.addEventListener('DOMContentLoaded', function () {
         `;
     }
 
-    tabs.forEach(tab => {
-        tab.addEventListener('click', e => {
-            e.preventDefault();
-
-            showSection(tab.dataset.tab);
-        });
-    });
-
-    sidebarLinks.forEach(link => {
-        link.addEventListener('click', e => {
-            e.preventDefault();
-            const targetId = link.getAttribute('href').substring(1);
-            showSection(targetId);
-
-        });
-    });
+    // sidebar links scroll to anchors normally
 
     httpMethodSelect.addEventListener('change', updateRequestPreview);
     addHeaderBtn.addEventListener('click', () => {

--- a/learn/n8n-api/ko.html
+++ b/learn/n8n-api/ko.html
@@ -11,10 +11,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
     <style>
         body { font-family: 'Noto Sans KR', sans-serif; background-color: #F9F9F9; color: #1f2937; }
-        .tab-active { border-bottom-color: #2563eb; color: #2563eb; font-weight: 500; }
-        .tab-inactive { border-bottom-color: transparent; color: #6b7280; }
-        .content-section { display: none; }
-        .content-section.active { display: block; }
+        /* sections are all visible by default */
         .code-block { background-color: #1f2937; color: #d1d5db; padding: 1rem; border-radius: 0.5rem; font-family: monospace; white-space: pre-wrap; word-break: break-all; }
         .chart-container { position: relative; width: 100%; max-width: 600px; margin-left: auto; margin-right: auto; height: 350px; max-height: 400px; }
     </style>
@@ -35,16 +32,7 @@
     </aside>
   <main class="flex-1">
         <section id="home" class="container mx-auto p-4 md:p-8">
-          <nav id="tab-nav" class="mb-8 border-b border-slate-200">
-
-                <ul class="flex flex-wrap -mb-px text-sm font-medium text-center">
-                    <li class="mr-2"><a href="#" class="inline-block p-4 border-b-2 rounded-t-lg tab-active" data-tab="home">개요</a></li>
-                    <li class="mr-2"><a href="#" class="inline-block p-4 border-b-2 rounded-t-lg tab-inactive" data-tab="http-basics">HTTP Request 기초</a></li>
-                    <li class="mr-2"><a href="#" class="inline-block p-4 border-b-2 rounded-t-lg tab-inactive" data-tab="linkedin">LinkedIn 연동</a></li>
-                    <li class="mr-2"><a href="#" class="inline-block p-4 border-b-2 rounded-t-lg tab-inactive" data-tab="notion">Notion 연동</a></li>
-                    <li><a href="#" class="inline-block p-4 border-b-2 rounded-t-lg tab-inactive" data-tab="advanced">고급 워크플로우</a></li>
-                </ul>
-            </nav>
+          <!-- removed page-level tab navigation -->
             <div class="bg-white p-6 rounded-lg shadow-sm">
                 <h2 class="text-2xl font-bold mb-4">n8n의 잠재력을 최대한 활용하기</h2>
                 <p class="mb-4 text-slate-600">이 가이드는 n8n의 <code>HTTP Request</code> 노드를 활용해 LinkedIn과 Notion과 같은 서비스의 API를 직접 호출하는 방법을 설명합니다. 기본 노드로는 구현할 수 없는 기능을 구현하고 비즈니스 요구에 맞춘 고급 자동화 워크플로우를 만드는 방법을 배울 수 있습니다.</p>
@@ -197,10 +185,6 @@
 
 <script>
 document.addEventListener('DOMContentLoaded', function () {
-   const tabs = document.querySelectorAll('#tab-nav a');
-    const sidebarLinks = document.querySelectorAll('aside .nav-link');
-
-    const sections = document.querySelectorAll('.content-section');
 
     const httpMethodSelect = document.getElementById('http-method');
     const addHeaderBtn = document.getElementById('add-header');
@@ -214,25 +198,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const accordionButtons = document.querySelectorAll('[data-accordion-target]');
 
 
-    function showSection(targetId) {
-        tabs.forEach(t => {
-            if (t.dataset.tab === targetId) {
-                t.classList.add('tab-active');
-                t.classList.remove('tab-inactive');
-            } else {
-                t.classList.remove('tab-active');
-                t.classList.add('tab-inactive');
-            }
-        });
-        sections.forEach(section => {
-            if (section.id === targetId) {
-                section.classList.add('active');
-            } else {
-                section.classList.remove('active');
-            }
-        });
-        document.getElementById(targetId)?.scrollIntoView({ behavior: 'smooth' });
-    }
+    // sections are navigated via normal anchors
 
     const linkedinData = {
         'li-text': {
@@ -376,22 +342,7 @@ document.addEventListener('DOMContentLoaded', function () {
         `;
     }
 
-    tabs.forEach(tab => {
-        tab.addEventListener('click', e => {
-            e.preventDefault();
-
-            showSection(tab.dataset.tab);
-        });
-    });
-
-    sidebarLinks.forEach(link => {
-        link.addEventListener('click', e => {
-            e.preventDefault();
-            const targetId = link.getAttribute('href').substring(1);
-            showSection(targetId);
-
-        });
-    });
+    // sidebar links scroll to anchors normally
 
     httpMethodSelect.addEventListener('change', updateRequestPreview);
     addHeaderBtn.addEventListener('click', () => {

--- a/load-header.js
+++ b/load-header.js
@@ -12,9 +12,20 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       const learnItem = document.getElementById('learn-item');
       const learnDropdown = document.getElementById('learn-dropdown');
-      if (learnItem && learnDropdown) {
-        learnItem.addEventListener('mouseenter', () => learnDropdown.classList.remove('hidden'));
-        learnItem.addEventListener('mouseleave', () => learnDropdown.classList.add('hidden'));
+      const navMenu = document.getElementById('nav-menu');
+      if (learnItem && learnDropdown && navMenu) {
+        const show = () => learnDropdown.classList.remove('hidden');
+        const hide = () => learnDropdown.classList.add('hidden');
+        [learnItem, learnDropdown].forEach(el => {
+          el.addEventListener('mouseenter', show);
+          el.addEventListener('mouseleave', hide);
+        });
+        navMenu.querySelectorAll('> li').forEach(li => {
+          if (li !== learnItem) {
+            li.addEventListener('mouseenter', show);
+          }
+        });
+        navMenu.addEventListener('mouseleave', hide);
       }
     })
     .catch(err => console.error('Failed to load header:', err));


### PR DESCRIPTION
## Summary
- keep learn menu open while hovering header
- link each menu item to its page
- add standalone `contact.html`
- remove redundant tab nav from n8n guide (en/ko)

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_685df017ddbc8328bd04e2b31bc6279e